### PR TITLE
fix: temporal fix to pydantic v2 changes

### DIFF
--- a/source/map/extractor/reader.py
+++ b/source/map/extractor/reader.py
@@ -8,7 +8,7 @@ from source.device.alas.config_utils import *
 from source.map.extractor.convert import MapConverter
 
 from source.en_tools.poi_json_api import zh2en
-
+from source.device.alas.config_utils import V2CompatBaseModel
 
 class PointItemModel(BaseModel):
     count: int
@@ -16,7 +16,7 @@ class PointItemModel(BaseModel):
     itemId: int
 
 
-class PointInfoModel(BaseModel):
+class PointInfoModel(V2CompatBaseModel):
     content: str
     hiddenFlag: int
     id: int


### PR DESCRIPTION
this pull request is aimed to raise attention to the changes pydantic v2 brings. 

this is to fix the following
```
_config.py:261: UserWarning: Valid config keys have changed in V2:
* 'keep_untouched' has been renamed to 'ignored_types'
```
# alternative methods 1
changing the file at `source\map\extractor\reader.py`
```

class PointInfoModel(BaseModel):
    content: str
    hiddenFlag: int
    id: int
    itemList: t.List[PointItemModel]
    markerCreatorId: int
    markerTitle: str
    picture: str = ''
    pictureCreatorId: int = 0
    position: str
    refreshTime: int
    version: int
    videoPath: str

    class Config:
        ignored_types = (cached_property,)

```
should work fine but may break some systems who still rely on an earlier version of pydantic
# alternative methods 2
or a forced version number for 
```
pydantic==1.10.11
```