### PR TITLE
修复无法自动点击秘境

### DIFF
--- a/source/task/domain/domain_task.py
+++ b/source/task/domain/domain_task.py
@@ -68,7 +68,7 @@ class DomainTask(TaskTemplate):
                                    mode=CONTAIN_MATCHING,
                                    extract_white_threshold=254)
         if p1 != -1:
-            if len(p1)>1:
+            if len(p1) > 1 and isinstance(p1[0], list):
                 p1 = p1[0]
             itt.move_and_click([p1[0] + 5, p1[1] + 5], delay=1)
         else:

--- a/source/task/task_manager.py
+++ b/source/task/task_manager.py
@@ -25,7 +25,7 @@ class TaskManager(BaseThreading):
         # if 'stop_task_flag' in args.exc_value.__dict__:
         exception_instance = args.exc_value
         logger.exception(exception_instance)
-        if isinstance(GIABaseException, exception_instance):
+        if isinstance(exception_instance, GIABaseException):
             if args.exc_value.stop_task_flag:
                 self.stop_tasklist()
             if len(exception_instance.POSSIBLE_REASONS) > 0:
@@ -33,7 +33,7 @@ class TaskManager(BaseThreading):
                 for pr in exception_instance.POSSIBLE_REASONS:
                     i+=1
                     logger.error(f'{t2t("Possible Reason")} {i}: {pr}')
-        if isinstance(SnapshotException, exception_instance):
+        if isinstance(exception_instance, SnapshotException):
             exception_instance.save_snapshot(itt.capture(jpgmode=FOUR_CHANNELS))
     
     def append_task(self, task_name):


### PR DESCRIPTION
之前一直有秘境自动导航后无法点击问题如下

![image](https://github.com/infstellar/genshin_impact_assistant/assets/36222458/0612acb2-1985-40ae-b566-f95a9f4463a8)

<details>

<summary>full logs...</summary>

```log
zh_CN
python "D:\Games\GIA\repositories\GIA_Launcher_Download_Lib/source/msgfmt.py" -o "D:\Games\GIA\repositories\GIA_Launcher_Download_Lib\translation/locale\zh_CN\LC_MESSAGES\zh_CN.mo" "D:\Games\GIA\repositories\GIA_Launcher_Download_Lib\translation/locale\zh_CN\LC_MESSAGES\zh_CN.po"
sha-1 verify cost: 0.32615232467651367
2023-12-13 19:56:23.106 | INFO     | source.interaction.interaction_core:__init__:76 - InteractionBGD created
2023-12-13 19:56:26.273 | INFO     | source.map.map:<module>:451 - genshin map object created
2023-12-13 19:56:26.577 | INFO     | __main__:<module>:35 - 正在初始化，请稍后
2023-12-13 19:56:26.578 | INFO     | __main__:<module>:55 - 初始化完成
2023-12-13 19:56:26.578 | INFO     | __main__:<module>:56 - 正在等待webio启动
2023-12-13 19:56:26.578 | INFO     | __main__:<module>:57 - 启动键盘监听
Running on all addresses.
Use http://172.21.2.10:22268/ to access the application
2023-12-13 19:56:26.972 | INFO     | source.webio.webio:main:49 - webio启动完成
2023-12-13 19:56:29.764 | INFO     | source.task.task_manager:start_stop_task:104 - 任务LaunchGenshinTask启动。
2023-12-13 19:56:31.967 | INFO     | source.api.pdocr_api:<module>:4 - 正在创建OCR对象
2023-12-13 19:56:32.104 | INFO     | source.api.pdocr_api:<module>:16 - import pdocr time: 0.14
2023-12-13 19:56:32.104 | INFO     | source.api.pdocr_api:__init__:57 - Creating PaddleOCRFastDeploy object: D:\Games\GIA\repositories\GIA_Launcher_Download_Lib\assets\PPOCRModels\zh_CN
WARNING: Logging before InitGoogleLogging() is written to STDERR
W1213 19:56:32.105633  9236 analysis_config.cc:971] It is detected that mkldnn and memory_optimize_pass are enabled at the same time, but they are not supported yet. Currently, memory_optimize_pass is explicitly disabled
[INFO] fastdeploy/runtime/runtime.cc(273)::fastdeploy::Runtime::CreatePaddleBackend     Runtime initialized with Backend::PDINFER in Device::CPU.
[INFO] fastdeploy/runtime/runtime.cc(273)::fastdeploy::Runtime::CreatePaddleBackend     Runtime initialized with Backend::PDINFER in Device::CPU.
2023-12-13 19:56:32.751 | INFO     | source.api.pdocr_api:__init__:66 - created DBDetector and Recognizer. cost 0.65
2023-12-13 19:56:32.752 | INFO     | source.api.pdocr_api:__init__:69 - created PPOCRv3. cost 0.0
2023-12-13 19:56:32.752 | INFO     | source.api.pdocr_complete:<module>:9 - created pdocr. cost 0.65 second.
2023-12-13 19:56:33.631 | INFO     | source.task.task_manager:loop:146 - task LaunchGenshinTask end.
2023-12-13 19:56:33.631 | INFO     | source.task.task_manager:start_stop_task:113 - 任务结束
2023-12-13 19:56:33.637 | INFO     | source.api.pdocr_api:__init__:57 - Creating PaddleOCRFastDeploy object: D:\Games\GIA\repositories\GIA_Launcher_Download_Lib\assets\PPOCRModels\en_US
[INFO] fastdeploy/runtime/runtime.cc(273)::fastdeploy::Runtime::CreatePaddleBackend     Runtime initialized with Backend::PDINFER in Device::CPU.
[INFO] fastdeploy/runtime/runtime.cc(273)::fastdeploy::Runtime::CreatePaddleBackend     Runtime initialized with Backend::PDINFER in Device::CPU.
2023-12-13 19:56:34.293 | INFO     | source.api.pdocr_api:__init__:66 - created DBDetector and Recognizer. cost 0.66
2023-12-13 19:56:34.294 | INFO     | source.api.pdocr_api:__init__:69 - created PPOCRv3. cost 0.0
2023-12-13 19:56:34.297 | INFO     | source.api.pdocr_light:<module>:5 - created pdocr. cost 0.66 second.
2023-12-13 19:56:34.304 | INFO     | source.api.yolox_api:<module>:6 - 正在创建YOLOX对象。这可能需要一些时间。
2023-12-13 19:56:36.449 | INFO     | source.api.yolox_api:<module>:534 - YOLOX对象已创建
2023-12-13 19:56:38.028 | INFO     | source.task.domain.domain_task:__init__:34 - domain_name: 山脊守望 domain_stage_name 不移IV domain times 1
2023-12-13 19:56:38.028 | INFO     | source.task.task_manager:start_stop_task:104 - 任务DomainTask启动。
2023-12-13 19:56:38.370 | INFO     | source.ui.ui:ui_goto:76 - UI goto page_bigmap
2023-12-13 19:56:40.006 | INFO     | source.map.map:reinit_smallmap:167 - init_position:[5037.536 1372.264]
2023-12-13 19:56:40.079 | INFO     | source.ui.ui:ui_goto:76 - UI goto page_main
2023-12-13 19:56:42.120 | INFO     | source.teyvat_move.teyvat_move_flow_upgrade:init_path:216 - 不在服务区
2023-12-13 19:56:42.607 | INFO     | source.ui.ui:ui_goto:76 - UI goto page_main
2023-12-13 19:56:43.256 | INFO     | source.ui.ui:ui_goto:76 - UI goto page_bigmap
2023-12-13 19:56:50.255 | WARNING  | source.ui.ui:get_page:39 - 未知Page, 重新检测
2023-12-13 19:56:51.290 | WARNING  | source.ui.ui:get_page:39 - 未知Page, 重新检测
2023-12-13 19:56:52.326 | INFO     | source.ui.ui:ui_goto:76 - UI goto page_bigmap
2023-12-13 19:56:53.968 | INFO     | source.map.map:reinit_smallmap:167 - init_position:[5037.536 1374.664]
2023-12-13 19:56:54.051 | INFO     | source.ui.ui:ui_goto:76 - UI goto page_main
2023-12-13 19:56:56.089 | INFO     | source.ui.ui:ui_goto:76 - UI goto page_main
2023-12-13 19:56:56.616 | INFO     | source.flow.utils.flow_template:enter_flow:45 - Flow Switch To: INIT_TEYVAT_MOVE
2023-12-13 19:56:56.840 | INFO     | source.map.map:reinit_smallmap:174 - init too fast, skip
2023-12-13 19:56:56.852 | INFO     | source.teyvat_move.teyvat_move_flow_upgrade:init_path:216 - 不在服务区
2023-12-13 19:56:57.060 | INFO     | source.map.map:get_rotation:226 - get_rotation spent too long: 0.12153434753417969
2023-12-13 19:56:59.432 | INFO     | source.teyvat_move.teyvat_move_flow_upgrade:detect_stop_rule:171 - 已到达F附近，本次导航结束。
2023-12-13 19:57:00.514 | INFO     | source.flow.utils.flow_template:enter_flow:45 - Flow Switch To: $END$TEYVAT_MOVE_PASS
2023-12-13 19:57:07.238 | ERROR    | source.task.task_manager:task_excepthook:27 - invalid index to scalar variable.
Traceback (most recent call last):

  File "D:\Games\GIA\installed_python\3.11_GIA_Launcher_Download_Lib\Lib\threading.py", line 1002, in _bootstrap
    self._bootstrap_inner()
    │    └ <function Thread._bootstrap_inner at 0x0000022171D6A8E0>
    └ <DomainTask(, started daemon 1808)>
> File "D:\Games\GIA\installed_python\3.11_GIA_Launcher_Download_Lib\Lib\threading.py", line 1045, in _bootstrap_inner
    self.run()
    │    └ <function BaseThreading.run at 0x000002210D39DD00>
    └ <DomainTask(, started daemon 1808)>

  File "D:\Games\GIA\repositories\GIA_Launcher_Download_Lib\source\common\base_threading.py", line 170, in run
    self.loop()
    │    └ <function DomainTask.loop at 0x0000022184A90AE0>
    └ <DomainTask(, started daemon 1808)>

  File "D:\Games\GIA\repositories\GIA_Launcher_Download_Lib\source\task\domain\domain_task.py", line 149, in loop
    self._enter_domain()
    │    └ <function DomainTask._enter_domain at 0x0000022184A90900>
    └ <DomainTask(, started daemon 1808)>

  File "D:\Games\GIA\repositories\GIA_Launcher_Download_Lib\source\task\domain\domain_task.py", line 73, in _enter_domain
    itt.move_and_click([p1[0] + 5, p1[1] + 5], delay=1)
    │   │               │          └ 173.0
    │   │               └ 173.0
    │   └ <function before_operation.<locals>.outwrapper.<locals>.wrapper at 0x000002217FF2C0E0>
    └ <source.interaction.interaction_core.InteractionBGD object at 0x000002217FF0BD10>

IndexError: invalid index to scalar variable.
Exception in threading.excepthook:
Traceback (most recent call last):
  File "D:\Games\GIA\installed_python\3.11_GIA_Launcher_Download_Lib\Lib\threading.py", line 1349, in invoke_excepthook
    hook(args)
  File "D:\Games\GIA\repositories\GIA_Launcher_Download_Lib\source\task\task_manager.py", line 28, in task_excepthook
    if isinstance(GIABaseException, exception_instance):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: isinstance() arg 2 must be a type, a tuple of types, or a union

```

</details>

今天检查了下，发现是坐标[被多展开了一次](https://github.com/infstellar/genshin_impact_assistant/blob/1417bc621c08939885ecefcef83f3481c73508fb/source/task/domain/domain_task.py#L70-L72)，故修复。

https://github.com/infstellar/genshin_impact_assistant/blob/1417bc621c08939885ecefcef83f3481c73508fb/source/task/domain/domain_task.py#L70-L72
